### PR TITLE
Fix symbolic link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,1 +1,1 @@
-../README
+../README.rst


### PR DESCRIPTION
I think this should fix #5. The `index.rst` symlink was referring to `README` rather than `README.rst`.

Would be awesome if you could cut a release reasonably soon. This is an awesome library I'm keen to integrate into our site. As soon as these Pypi issues are resolved I'll be able to. :smile: 
