### PR TITLE
Remove setuptools version 0.8 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,6 @@ setup(
     url='https://github.com/rbarrois/python-semanticversion',
     download_url='http://pypi.python.org/pypi/semantic_version/',
     packages=['semantic_version'],
-    setup_requires=[
-        'setuptools>=0.8',
-    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Having a requirement os setuptools >=0.8 is a bit annoying since the last version to date in Pypi is 0.7
https://pypi.python.org/pypi/setuptools/7.0

I've removed the requirement and tested installing this ok in setuptools-0.6c11, 
Maybe there's a reason for this requirement that I am missing?
