### PR TITLE
Fixed Missing CREDITS and LICENSE file in pip tarball version 2.3.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include README.rst
 include ChangeLog
+include LICENSE
+include CREDITS
 include docs/Makefile
 recursive-include docs *.py *.rst
 include docs/_static/.keep_dir


### PR DESCRIPTION
The current pypi tarball of python-semanticversion version 2.3.1
does not includes CREDITS and LICENSE file.
Documentation is also failing due to this.

This closes #20 