### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014 The python-semanticversion project
+Copyright (c) 2012-2015 The python-semanticversion project
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/semantic_version/__init__.py
+++ b/semantic_version/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 

--- a/semantic_version/base.py
+++ b/semantic_version/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 from __future__ import unicode_literals

--- a/semantic_version/compat.py
+++ b/semantic_version/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 import sys

--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 from __future__ import unicode_literals

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 
 
 import codecs

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 import sys
@@ -11,4 +11,3 @@ try:  # pragma: no cover
     import unittest2 as unittest
 except ImportError:  # pragma: no cover
     import unittest
-

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 """Test the various functions from 'base'."""

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 from __future__ import unicode_literals

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 import unittest
@@ -131,4 +131,3 @@ class MatchTestCase(unittest.TestCase):
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()
-

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 import unittest

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2012-2014 The python-semanticversion project
+# Copyright (c) 2012-2015 The python-semanticversion project
 # This code is distributed under the two-clause BSD License.
 
 """Test conformance to the specs."""
@@ -159,5 +159,3 @@ class FormatTests(unittest.TestCase):
 
 class PrecedenceTestCase(unittest.TestCase):
     pass
-
-


### PR DESCRIPTION
Split out from #25. Updates the copyright notice years to note include this year (2015).