### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ It follows strictly the 2.0.0 version of the SemVer scheme.
     :target: http://travis-ci.org/rbarrois/python-semanticversion/
 
 .. image:: https://img.shields.io/pypi/v/semantic_version.svg
-    :target: http://python-semanticversion.readthedocs.org/en/latest/changelog.html
+    :target: https://python-semanticversion.readthedocs.io/en/latest/changelog.html
     :alt: Latest Version
 
 .. image:: https://img.shields.io/pypi/pyversions/semantic_version.svg
@@ -27,7 +27,7 @@ Links
 -----
 
 - Package on `PyPI`_: http://pypi.python.org/pypi/semantic_version/
-- Doc on `ReadTheDocs <http://readthedocs.org/>`_: http://readthedocs.org/docs/python-semanticversion/
+- Doc on `ReadTheDocs <http://readthedocs.org/>`_: https://python-semanticversion.readthedocs.io/
 - Source on `GitHub <http://github.com/>`_: http://github.com/rbarrois/python-semanticversion/
 - Build on `Travis CI <http://travis-ci.org/>`_: http://travis-ci.org/rbarrois/python-semanticversion/
 - Semantic Version specification: `SemVer`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.