### PR TITLE
remove use of deprecated SubfieldBase

### DIFF
--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -25,7 +25,7 @@ class BaseSemVerField(models.CharField):
         return value
 
     def value_to_string(self, obj):
-        value = self.to_python(self._get_val_from_obj(obj))
+        value = self.to_python(self.value_from_object(obj))
         return str(value)
 
     def run_validators(self, value):


### PR DESCRIPTION
SubfieldBase was deprecated in Django 1.8 and was replaced by Field.from_db_value. This changes the behaviour of the Version and SpecField. When using SubfieldBase Field.to_python was called on assignment of the field. This is not the case anymore when using Field.from_db_value. See the Django documentation https://docs.djangoproject.com/en/1.9/howto/custom-model-fields/#changing-a-custom-field-s-base-class
This is also the reason for the full_clean calls in the tests.

this fixes #43 