### PR TITLE
Make class names dynamic in Version.__repr__

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -17,6 +17,7 @@ Contributors
 
 The project has received contributions from (in alphabetical order):
 
+* Kyle Baird <kylegbaird@gmail.com> (https://github.com/kgbaird)
 * Raphaël Barrois <raphael.barrois+semver@polytechnique.org> (https://github.com/rbarrois)
 * Rick Eyre <rick.eyre@outlook.com> (https://github.com/rickeyre)
 * Hugo Rodger-Brown <hugo@yunojuno.com> (https://github.com/yunojuno)

--- a/semantic_version/base.py
+++ b/semantic_version/base.py
@@ -271,7 +271,8 @@ class Version(object):
         return version
 
     def __repr__(self):
-        return 'Version(%r%s)' % (
+        return '%s(%r%s)' % (
+            self.__class__.__name__,
             str(self),
             ', partial=True' if self.partial else '',
         )


### PR DESCRIPTION
This should allow for the `__repr__` of subclasses to use the name of the subclass instead of the potentially misleading hard coded `Version`. I created this in response to issue #55.