### PR TITLE
Add support for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,19 @@ matrix:
       env: TOXENV=py35-django18
       env: TOXENV=py35-django19
       env: TOXENV=py35-django110
-
+    - python: "3.6"
+      env: TOXENV=py36-django17
+      env: TOXENV=py36-django18
+      env: TOXENV=py36-django19
+      env: TOXENV=py36-django110
     # Pypy
     - python: "pypy"
       env: TOXENV=py27-django110
 
     # Linting
     - python: "3.5"
+      env: TOXENV=lint
+    - python: "3.6"
       env: TOXENV=lint
 
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     test_suite='tests',


### PR DESCRIPTION
Gentoo has recently [switched to Python 3.6 as default](https://www.gentoo.org/support/news-items/2018-05-22-python3-6.html). It seems that semantic_version works just fine with 3.6, too.

Signed-off-by: Igor Kotrasinski <i.kotrasinsk@gmail.com>