### PR TITLE
Non numeric identifier comparison

### DIFF
--- a/semantic_version/base.py
+++ b/semantic_version/base.py
@@ -24,7 +24,6 @@ def _has_leading_zero(value):
             and value.isdigit()
             and value != '0')
 
-
 def identifier_cmp(a, b):
     """Compare two identifier (for pre-release/build components)."""
 
@@ -40,8 +39,11 @@ def identifier_cmp(a, b):
     elif b_is_int:
         return 1
     else:
-        # Non-numeric identifiers are compared lexicographically
-        return base_cmp(a_cmp, b_cmp)
+        # Non-numeric identifiers are compared by a natural comparison
+        # adapted from https://stackoverflow.com/questions/8408125/python-natural-comparison-between-strings
+        convert = lambda text: int(text) if text.isdigit() else text.lower()
+        alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key) ]
+        return base_cmp(alphanum_key(a_cmp), alphanum_key(b_cmp))
 
 
 def identifier_list_cmp(a, b):

--- a/semantic_version/base.py
+++ b/semantic_version/base.py
@@ -24,6 +24,7 @@ def _has_leading_zero(value):
             and value.isdigit()
             and value != '0')
 
+
 def identifier_cmp(a, b):
     """Compare two identifier (for pre-release/build components)."""
 


### PR DESCRIPTION
When I have multiple Release candidate revisions, such as the following:

2.2.0-RC1, 
2.2.0-RC2
.... 
2.2.0-RC9
2.2.0-RC10

comparing revisions works fine until I get to a multi-digit revision such as RC10. This is because the identifiers are compared 'lexicographcally' as per the source. 
```
>>> import semantic_version
>>> a = semantic_version.Version('2.2.0-RC9')
>>> b = semantic_version.Version('2.2.0-RC10')
>>> b < a
True
>>> a < b
False
```

I propose my included code to compare non-numeric identifiers in a 'natural' way which resolves my issue above and works I believe in all cases. 

See below:

```
>>> a = semantic_version.Version('2.2.0-RC9')
>>> b = semantic_version.Version('2.2.0-RC10')
>>> a < b
True
>>> b < a
False
>>> a = semantic_version.Version('2.2.0-RC9A')
>>> b = semantic_version.Version('2.2.0-RC9B')
>>> a < b
True
>>> a = semantic_version.Version('2.2.0-RC9A2')
>>> a = semantic_version.Version('2.2.0-RC9A3')
>>> a < b
True
>>> a = semantic_version.Version('2.2.0-RC10A2')
>>> a < b
False

```

My mods are from a stack overflow question about natural comparisons here: [Stack Overflow: python natural comparison between strings?
](https://stackoverflow.com/questions/8408125/python-natural-comparison-between-strings)