### PR TITLE
Update python versions, drop support for Django 1.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ install:
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27-django111
-    - python: "3.4"
-      env: TOXENV=py34-django111
-    - python: "3.6"
-      env: TOXENV=py36-django111
     - python: "3.6"
       env: TOXENV=py36-django22
+    - python: "3.7"
+      env: TOXENV=py37-django22
+    - python: "3.8"
+      env: TOXENV=py38-django22
 
     # Pypy
     - python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,26 @@ matrix:
       env: TOXENV=py37-django22
     - python: "3.8"
       env: TOXENV=py38-django22
+    - python: "3.6"
+      env: TOXENV=py36-django30
+    - python: "3.7"
+      env: TOXENV=py37-django30
+    - python: "3.8"
+      env: TOXENV=py38-django30
+    - python: "3.6"
+      env: TOXENV=py36-django31
+    - python: "3.7"
+      env: TOXENV=py37-django31
+    - python: "3.8"
+      env: TOXENV=py38-django31
 
     # Pypy
     - python: "pypy3"
       env: TOXENV=pypy3-django22
+    - python: "pypy3"
+      env: TOXENV=pypy3-django30
+    - python: "pypy3"
+      env: TOXENV=pypy3-django31
 
     # Linting
     - python: "3.6"

--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -5,7 +5,7 @@
 import warnings
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import base
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url='https://github.com/rbarrois/python-semanticversion',
     download_url='http://pypi.python.org/pypi/semantic_version/',
     packages=['semantic_version'],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.5",
     setup_requires=[
         'setuptools>=0.8',
     ],
@@ -61,12 +61,11 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,37}-django111
-    py{35,36,37}-django22
+    py{35,36,37,38}-django22
     pypy3-django{111,22}
     lint
 
@@ -10,7 +9,6 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 [testenv]
 deps =
     -rrequirements_test.txt
-    django111: Django>=1.11,<1.12
     django22: Django>=2.2,<2.3
 
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django22
-    pypy3-django{111,22}
+    py{35,36,37,38}-django{22,30,31}
+    pypy3-django{22}
     lint
 
 toxworkdir = {env:TOX_WORKDIR:.tox}
@@ -10,6 +10,8 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 deps =
     -rrequirements_test.txt
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
* No longer test unsupported Python versions (2.7, 3.4 - see [Status of Python branches](https://devguide.python.org/#status-of-python-branches))
* Test Python3.7 and 3.8.
* Drop support for Django<2.2 (see [Supported Versions](https://www.djangoproject.com/download/))
* Add support for Django 3.0 and 3.1.
* Replace deprecated `ugettext_lazy` with `gettext_lazy`.