### PR TITLE
Run tests through unittest directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ testall:
 
 # DOC: Run tests for the currently installed version
 test:
-	python -Wdefault setup.py test
+	python -Wdefault -m unittest
 
 # DOC: Perform code quality tasks
 lint: check-manifest flake8


### PR DESCRIPTION
Instead of using `python setup.py test` (which is deprecated), move to
the standard `python -m unittest`.