### PR TITLE
Fix Django 4.0 compatibility

### DIFF
--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -5,7 +5,7 @@
 import warnings
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import base
 


### PR DESCRIPTION
This PR replaces deprecated ugettext_lazy with gettext_lazy (issue #113)

This is *required* for Django 4.0 which is officially in beta testing and will be released early December 2021