### PR TITLE
Add Django 4.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,33 +14,33 @@ jobs:
       matrix:
         include:
           # Django 1.11: 3.4, 3.7
-          - python-version: 2.7
+          - python-version: "2.7"
             django-family: 111
-          - python-version: 3.4
+          - python-version: "3.4"
             django-family: 111
-          - python-version: 3.7
+          - python-version: "3.7"
             django-family: 111
-          - python-version: pypy3
+          - python-version: "pypy3"
             django-family: 111
 
           # Django 2.2: 3.5, 3.7, 3.8
-          - python-version: 3.5
+          - python-version: "3.5"
             django-family: 22
-          - python-version: 3.7
+          - python-version: "3.7"
             django-family: 22
-          - python-version: 3.8
+          - python-version: "3.8"
             django-family: 22
-          - python-version: pypy3
+          - python-version: "pypy3"
             django-family: 22
 
           # Django 3.1: Python 3.6, 3.8, 3.9
-          - python-version: 3.6
+          - python-version: "3.6"
             django-family: 31
-          - python-version: 3.8
+          - python-version: "3.8"
             django-family: 31
-          - python-version: 3.9
+          - python-version: "3.9"
             django-family: 31
-          - python-version: pypy3
+          - python-version: "pypy3"
             django-family: 31
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,14 @@ jobs:
           - python-version: "pypy3"
             django-family: 32
 
+          # Django 4.0: Python 3.8, 3.9, 3.10
+          - python-version: "3.8"
+            django-family: 40
+          - python-version: "3.9"
+            django-family: 40
+          - python-version: "3.10"
+            django-family: 40
+
     env:
       TOXENV: django${{ matrix.django-family }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Django 1.11: 3.4, 3.7
+          # Django 1.11: 3.5, 3.7
           - python-version: "2.7"
             django-family: 111
-          - python-version: "3.4"
+          - python-version: "3.5"
             django-family: 111
           - python-version: "3.7"
             django-family: 111

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,17 @@ jobs:
           - python-version: "pypy3"
             django-family: 22
 
-          # Django 3.1: Python 3.6, 3.8, 3.9
+          # Django 3.2: Python 3.6, 3.8, 3.9, 3.10
           - python-version: "3.6"
-            django-family: 31
+            django-family: 32
           - python-version: "3.8"
-            django-family: 31
+            django-family: 32
           - python-version: "3.9"
-            django-family: 31
+            django-family: 32
+          - python-version: "3.10"
+            django-family: 32
           - python-version: "pypy3"
-            django-family: 31
+            django-family: 32
 
     env:
       TOXENV: django${{ matrix.django-family }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,8 +6,8 @@ ChangeLog
 
 *New:*
 
-    * Add support for Django 3.1
-    * Add support for Python 3.7 / 3.8 / 3.9
+    * Add support for Django 3.1, 3.2, 4.0
+    * Add support for Python 3.7 / 3.8 / 3.9 / 3.10
 
 
 2.8.5 (2020-04-29)

--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -4,8 +4,14 @@
 
 import warnings
 
+import django
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+
+if django.VERSION >= (3, 0):
+    # See https://docs.djangoproject.com/en/dev/releases/3.0/#features-deprecated-in-3-0
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 from . import base
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     py{27,34,35,36,37}-django111
     py{35,36,37,38}-django22
-    py{36,37,38,39}-django31
-    pypy3-django{111,22,31}
+    py{36,37,38,39,310}-django32
+    pypy3-django{111,22,32}
     lint
 
 toxworkdir = {env:TOX_WORKDIR:.tox}
@@ -13,7 +13,7 @@ extras = dev
 deps =
     django111: Django>=1.11,<1.12
     django22: Django>=2.2,<2.3
-    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 
 whitelist_externals = make
 commands = make test

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,34,35,36,37}-django111
     py{35,36,37,38}-django22
     py{36,37,38,39,310}-django32
+    py{38,39,310}-django40
     pypy3-django{111,22,32}
     lint
 
@@ -14,6 +15,7 @@ deps =
     django111: Django>=1.11,<1.12
     django22: Django>=2.2,<2.3
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0a1,<4.1
 
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
Closes #121 ; #113 ; #122.

The actual implementation keeps the backwards compatibility with previous Python and Django versions.