### PR TITLE
Update the Version.parse() doc to match the code

### DIFF
--- a/semantic_version/base.py
+++ b/semantic_version/base.py
@@ -290,7 +290,8 @@ class Version(object):
 
     @classmethod
     def parse(cls, version_string, partial=False, coerce=False):
-        """Parse a version string into a Version() object.
+        """Parse a version string into a tuple of components:
+           (major, minor, patch, prerelease, build).
 
         Args:
             version_string (str), the version string to parse


### PR DESCRIPTION
The docstring was lying by saying a Version object was returned.
Rather this function returns a tuple of version parts.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>