### PR TITLE
Guarantee a stable ordering with build metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,14 @@
 ChangeLog
 =========
 
-2.9.1 (unreleased)
-------------------
+2.10.0 (unreleased)
+-------------------
 
-- Nothing changed yet.
+*New:*
+
+    * `132 <https://github.com/rbarrois/python-semanticversion/issues/132>`_:
+      Ensure sorting a collection of versions is always stable, even with
+      build metadata.
 
 
 2.9.0 (2022-02-06)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -130,7 +130,16 @@ Representing a version (the Version class)
         The actual value of the attribute is considered an implementation detail; the only
         guarantee is that ordering versions by their precedence_key will comply with semver precedence rules.
 
-        Note that the :attr:`~Version.build` isn't included in the precedence_key computatin.
+
+        .. warning::
+
+           .. versionchanged:: 2.10.0
+
+           The :attr:`~Version.build` is included in the precedence_key computation, but
+           only for ordering stability.
+           The only guarantee is that, for a given release of python-semanticversion, two versions'
+           :attr:`~Version.precedence_key` will always compare in the same direction if they include
+           build metadata; that ordering is an implementation detail and shouldn't be relied upon.
 
     .. attribute:: partial
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -229,6 +229,20 @@ class VersionTestCase(unittest.TestCase):
         self.assertTrue(v != '0.1.0')
         self.assertFalse(v == '0.1.0')
 
+    def test_stable_ordering(self):
+        a = [
+            base.Version('0.1.0'),
+            base.Version('0.1.0+a'),
+            base.Version('0.1.0+a.1'),
+            base.Version('0.1.1-a1'),
+        ]
+        b = [a[1], a[3], a[0], a[2]]
+
+        self.assertEqual(
+            sorted(a, key=lambda v: v.precedence_key),
+            sorted(b, key=lambda v: v.precedence_key),
+        )
+
     def test_bump_clean_versions(self):
         # We Test each property explicitly as the == comparator for versions
         # does not distinguish between prerelease or builds for equality.


### PR DESCRIPTION
Sorting any permutation of Version objects should always yield the same
result, even if those hold some build metadata.

To that end, the "precedence_key" is now used exclusively for sorting;
direct comparisons between Version objects still ignores the "build"
metadata, using a different precedence key.

For performance improvements, both precedence keys are cached.

Closes: #132