### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ author = Raphaël Barrois
 author_email = raphael.barrois+semver@polytechnique.org
 url = https://github.com/rbarrois/python-semanticversion
 keywords = semantic version, versioning, version
-license = BSD
+license = BSD-2-Clause
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Use SPDX license identifier: BSD-2-Clause
This will help tools to produce valid SPDX.