### PR TITLE
Made VersionField raise correct Django exception

### DIFF
--- a/semantic_version/django_fields.py
+++ b/semantic_version/django_fields.py
@@ -6,6 +6,7 @@ import warnings
 
 import django
 from django.db import models
+from django.core.exceptions import ValidationError
 
 if django.VERSION >= (3, 0):
     # See https://docs.djangoproject.com/en/dev/releases/3.0/#features-deprecated-in-3-0
@@ -75,10 +76,14 @@ class VersionField(SemVerField):
             return value
         if isinstance(value, base.Version):
             return value
-        if self.coerce:
-            return base.Version.coerce(value, partial=self.partial)
-        else:
-            return base.Version(value, partial=self.partial)
+        
+        try:
+            if self.coerce:
+                return base.Version.coerce(value, partial=self.partial)
+            else:
+                return base.Version(value, partial=self.partial)
+        except ValueError as e:
+            raise ValidationError(str(e)) from e
 
 
 class SpecField(SemVerField):


### PR DESCRIPTION
When using the Django `VersionField` if a string doesn't match the semver formatting a `ValueError` is raised. This is an issue because Django interprets this as a 500 server error instead of an issue with the user's input. The [Django docs](https://docs.djangoproject.com/en/4.0/howto/custom-model-fields/#converting-values-to-python-objects) indicate that you should raise a [`ValidationError`](https://docs.djangoproject.com/en/4.0/ref/exceptions/#django.core.exceptions.ValidationError) in order for the correct machinery to display this error to the user.